### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,6 @@
 name: CI
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/egvimo/apprise-api-headless/security/code-scanning/1](https://github.com/egvimo/apprise-api-headless/security/code-scanning/1)

To fix the issue, add an explicit `permissions` block to the workflow or the jobs.  
Since both jobs (`test` and `build`) only read repository contents and perform operations that do not require write access, the least privilege setting is likely `contents: read`.  
This can be set either at the workflow level (outside `jobs:`) or at the job level for additional granularity. For simplicity and minimal privilege, add it at the workflow root so that both jobs inherit the same restrictive permissions (unless a job requires different permissions in the future).  
Make the edit at the top of the `.github/workflows/ci.yml` file, directly after the `name:` declaration and before the `on:` trigger block.

No imports or additional logic required, only a YAML configuration change.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
