### PR TITLE
Potential fix for code scanning alert no. 3: Uncontrolled data used in path expression

### DIFF
--- a/apprise_api_headless/apprise.py
+++ b/apprise_api_headless/apprise.py
@@ -14,10 +14,15 @@ def get_apprise_instance(config_dir: str, config_key: str) -> Optional[Apprise]:
         return None
 
     config_path = None
+    # Ensure config_key does not escape config_dir via path traversal
     for ext in ["yml", "yaml"]:
         candidate_path = os.path.join(config_dir, f"{config_key}.{ext}")
-        if os.path.isfile(candidate_path):
-            config_path = candidate_path
+        norm_candidate_path = os.path.normpath(os.path.abspath(candidate_path))
+        norm_config_dir = os.path.normpath(os.path.abspath(config_dir))
+        if not norm_candidate_path.startswith(norm_config_dir + os.sep):
+            continue
+        if os.path.isfile(norm_candidate_path):
+            config_path = norm_candidate_path
             break
 
     if config_path is None:


### PR DESCRIPTION
Potential fix for [https://github.com/egvimo/apprise-api-headless/security/code-scanning/3](https://github.com/egvimo/apprise-api-headless/security/code-scanning/3)

To fix this issue, the code should ensure that any user-supplied value (`config_key`) cannot cause access to files outside the intended configuration directory. The recommended approach is to normalize the computed path using `os.path.normpath` (or `os.path.realpath` for absolute resolution), and then verify that it stays within the intended root directory (`config_dir`). Specifically, after joining `config_dir` and the potential filename (`config_key + extension`), normalize the result, and check that its absolute path starts with the absolute path of `config_dir`. If not, skip that file or raise an error. This change should be implemented within the file apprise_api_headless/apprise.py, specifically in the for-loop where candidate paths are considered (lines 17-22). Prior to passing the path to `os.path.isfile`, perform normalization and containment checks.

The required steps:

- After joining config_dir and filename, calculate the normalized absolute path.
- Calculate the normalized absolute path of config_dir.
- Check that the candidate path starts with the config_dir path (using `os.path.commonpath` for cross-platform support).
- Only consider files passing the containment test.

No new imports are needed beyond standard `os.path` functionality.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
